### PR TITLE
msm8974: Rename audio vendor effects

### DIFF
--- a/audio/audio_effects.conf
+++ b/audio/audio_effects.conf
@@ -36,11 +36,11 @@ libraries {
   proxy {
     path /system/lib/soundfx/libeffectproxy.so
   }
-  offload_bundle {
-    path /system/lib/soundfx/libqcompostprocbundle.so
-  }
-  qcom_pre_processing {
+  audio_pre_processing {
     path /system/lib/soundfx/libqcomvoiceprocessing.so
+  }
+  qcom_post_processing_hw {
+    path /system/lib/soundfx/libqcompostprocbundle.so
   }
 }
 
@@ -99,7 +99,7 @@ effects {
     }
 
     libhw {
-      library offload_bundle
+      library qcom_post_processing_hw
       uuid 2c4a8c24-1581-487f-94f6-0002a5d5c51b
     }
   }
@@ -113,7 +113,7 @@ effects {
     }
 
     libhw {
-      library offload_bundle
+      library qcom_post_processing_hw
       uuid 509a4498-561a-4bea-b3b1-0002a5d5c51b
     }
   }
@@ -127,7 +127,7 @@ effects {
     }
 
     libhw {
-      library offload_bundle
+      library qcom_post_processing_hw
       uuid a0dac280-401c-11e3-9379-0002a5d5c51b
     }
   }
@@ -145,7 +145,7 @@ effects {
     }
 
     libhw {
-      library offload_bundle
+      library qcom_post_processing_hw
       uuid 79a18026-18fd-4185-8233-0002a5d5c51b
     }
   }
@@ -159,7 +159,7 @@ effects {
     }
 
     libhw {
-      library offload_bundle
+      library qcom_post_processing_hw
       uuid eb64ea04-973b-43d2-8f5e-0002a5d5c51b
     }
   }
@@ -173,7 +173,7 @@ effects {
     }
 
     libhw {
-      library offload_bundle
+      library qcom_post_processing_hw
       uuid 6987be09-b142-4b41-9056-0002a5d5c51b
     }
   }
@@ -187,7 +187,7 @@ effects {
     }
 
     libhw {
-      library offload_bundle
+      library qcom_post_processing_hwo
       uuid aa2bebf6-47cf-4613-9bca-0002a5d5c51b
     }
   }
@@ -214,11 +214,11 @@ effects {
     uuid fa415329-2034-4bea-b5dc-5b381c8d1e2c
   }
   aec {
-    library qcom_pre_processing
+    library audio_pre_processing
     uuid 685707c0-0306-11e6-be79-0002a5d5c51b
   }
   ns {
-    library qcom_pre_processing
+    library audio_pre_processing
     uuid 72d30d20-0306-11e6-9860-0002a5d5c51b
   }
 }


### PR DESCRIPTION
Change-Id: I1c602f587129481790a6a1ca0188e7d3097d3390

# WE DO NOT MERGE PULL REQUESTS SUBMITTED HERE

You will need to submit it through [LineageOS Gerrit](https://review.lineageos.org/#/admin/projects/LineageOS/android_device_sony_msm8974-common)

