### PR TITLE
msm8974-common: remove persist.camera.HAL3.enabled prop

### DIFF
--- a/systemprop.mk
+++ b/systemprop.mk
@@ -71,8 +71,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.qc.sdk.camera.facialproc=false \
     ro.qc.sdk.gestures.camera=false \
-    camera.disable_zsl_mode=1 \
-    persist.camera.HAL3.enabled=0
+    camera.disable_zsl_mode=1
 
 # CameraAV MM HAL1 hacks
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
* Our camera HAL has no support for HAL3 anyway, this does nothing

Change-Id: Ida85f85d227745fa089700fe276c44db185b6e4b

# WE DO NOT MERGE PULL REQUESTS SUBMITTED HERE

You will need to submit it through [LineageOS Gerrit](https://review.lineageos.org/#/admin/projects/LineageOS/android_device_sony_msm8974-common)

